### PR TITLE
Comment API

### DIFF
--- a/instaclone/api.py
+++ b/instaclone/api.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-# from instaclone.app.comment.views import comment_router
+from instaclone.app.comment.views import comment_router
 from instaclone.app.medium.views import medium_router
 from instaclone.app.follower.views import follower_router
 from instaclone.app.post.views import post_router
@@ -9,7 +9,7 @@ from instaclone.app.user.views import user_router
 
 api_router = APIRouter()
 
-# api_router.include_router(comment_router, prefix="/comments", tags=["comments"])
+api_router.include_router(comment_router, prefix="/comments", tags=["comments"])
 api_router.include_router(medium_router, prefix="/medium", tags=["medium"])
 api_router.include_router(follower_router, prefix="/follower", tags=["follower"])
 api_router.include_router(post_router, prefix="/post", tags=["post"])

--- a/instaclone/app/comment/dto/requests.py
+++ b/instaclone/app/comment/dto/requests.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 class CommentCreateRequest(BaseModel):
     comment_text: str
     post_id: int
-    parent_id: int
+    parent_id: int | None = None
 
 class CommentEditRequest(BaseModel):
     comment_text: str

--- a/instaclone/app/comment/dto/requests.py
+++ b/instaclone/app/comment/dto/requests.py
@@ -1,9 +1,29 @@
-from pydantic import BaseModel
+from typing import TypeVar, Callable, Annotated, Optional
+from pydantic import BaseModel, AfterValidator
+from functools import wraps
+
+from instaclone.app.comment.errors import CommentLengthLimitError
+
+T = TypeVar("T")
+def skip_none(validator: Callable[[T], T]) -> Callable[[T | None], T | None]:
+    @wraps(validator)
+    def wrapper(value: T | None) -> T | None:
+        if value is None:
+            return value
+        return validator(value)
+
+    return wrapper
+
+def validate_comment_text(comment_text: str) -> str:
+    if len(comment_text) > 200:
+        raise CommentLengthLimitError()
+    
+    return comment_text
 
 class CommentCreateRequest(BaseModel):
-    comment_text: str
+    comment_text: Annotated[str, AfterValidator(skip_none(validate_comment_text))]
     post_id: int
-    parent_id: int | None = None
+    parent_id: Optional[int] = None
 
 class CommentEditRequest(BaseModel):
-    comment_text: str
+    comment_text: Annotated[str, AfterValidator(skip_none(validate_comment_text))]

--- a/instaclone/app/comment/dto/requests.py
+++ b/instaclone/app/comment/dto/requests.py
@@ -1,13 +1,9 @@
-# from typing import Annotated
-# from pydantic import AfterValidator, BaseModel
+from pydantic import BaseModel
 
-# from instaclone.common.errors import InvalidFieldFormatError
+class CommentCreateRequest(BaseModel):
+    comment_text: str
+    post_id: int
+    parent_id: int
 
-# # Validation definitions
-# def validateComment(text: str | None) -> str | None:
-#     return
-
-# class CommentCreateRequest(BaseModel):
-#     comment_text: Annotated[str, AfterValidator(validateComment)]
-#     post_id: int
-#     parent_id: int
+class CommentEditRequest(BaseModel):
+    comment_text: str

--- a/instaclone/app/comment/dto/responses.py
+++ b/instaclone/app/comment/dto/responses.py
@@ -1,10 +1,11 @@
 from typing import List
 from pydantic import BaseModel
+from sqlalchemy.sql import select
 
 from instaclone.app.comment.models import Comment
 from instaclone.app.user.models import User
 from instaclone.app.post.models import Post
-
+from instaclone.database.annotation import SESSION
 
 class CommentDetailResponse(BaseModel):
     comment_id: int
@@ -12,15 +13,26 @@ class CommentDetailResponse(BaseModel):
     post_id: int
     parent_id: int | None
     comment_text: str
-    replies: List[int]
 
     @staticmethod
-    async def from_comment(comment: Comment) -> "CommentDetailResponse":
+    def from_comment(comment: Comment) -> "CommentDetailResponse":
         return CommentDetailResponse(
             comment_id=comment.comment_id,
             user_id=comment.user_id,
             post_id=comment.post_id,
             parent_id=comment.parent_id,
             comment_text=comment.comment_text,
-            replies=[re.comment_id for re in comment.replies]
+        )
+    
+class ReplyDetailResponse(BaseModel):
+    comment_id: int
+    user_id: int
+    comment_text: str
+
+    @staticmethod
+    def from_reply(reply: Comment) -> "ReplyDetailResponse":
+        return ReplyDetailResponse(
+            comment_id=reply.comment_id,
+            user_id=reply.user_id,
+            comment_text=reply.comment_text
         )

--- a/instaclone/app/comment/dto/responses.py
+++ b/instaclone/app/comment/dto/responses.py
@@ -1,36 +1,26 @@
-# from typing import Self
-# from pydantic import BaseModel
+from typing import List
+from pydantic import BaseModel
 
-# from instaclone.app.comment.models import Comment
-# from instaclone.app.user.models import User
-# from instaclone.app.post.models import Post
+from instaclone.app.comment.models import Comment
+from instaclone.app.user.models import User
+from instaclone.app.post.models import Post
 
 
-# class CommentDetailResponse(BaseModel):
-#     comment_id: int
-#     user_id: int
-#     post_id: int
-#     parent: int | None
-#     comment_text: str
-#     replies: list[int]
+class CommentDetailResponse(BaseModel):
+    comment_id: int
+    user_id: int
+    post_id: int
+    parent_id: int | None
+    comment_text: str
+    replies: List[int]
 
-#     @staticmethod
-#     def from_comment(comment: Comment) -> "CommentDetailResponse":
-#         if comment.parent:
-#             parent = comment.parent
-#             parent_id = parent.comment_id
-#         else:
-#             parent_id = None
-#         reply_ids = []
-#         if comment.replies:
-#             for reply in comment.replies:
-#                 reply_ids.append(reply.comment_id)
-
-#         return CommentDetailResponse(
-#             comment_id=comment.comment_id,
-#             user_id=comment.user_id,
-#             post_id=comment.post_id,
-#             parent=parent_id,
-#             comment_text=comment.comment_text,
-#             replies=reply_ids
-#         )
+    @staticmethod
+    async def from_comment(comment: Comment) -> "CommentDetailResponse":
+        return CommentDetailResponse(
+            comment_id=comment.comment_id,
+            user_id=comment.user_id,
+            post_id=comment.post_id,
+            parent_id=comment.parent_id,
+            comment_text=comment.comment_text,
+            replies=[re.comment_id for re in comment.replies]
+        )

--- a/instaclone/app/comment/errors.py
+++ b/instaclone/app/comment/errors.py
@@ -1,6 +1,6 @@
 from instaclone.common.errors import InstacloneHttpException
 
-from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
 class CommentNotFoundError(InstacloneHttpException):
     def __init__(self) -> None:
@@ -9,3 +9,11 @@ class CommentNotFoundError(InstacloneHttpException):
 class CommentPermissionError(InstacloneHttpException):
     def __init__(self) -> None:
         super().__init__(HTTP_401_UNAUTHORIZED, "Comment Permission Error")
+
+class CommentLengthLimitError(InstacloneHttpException):
+    def __init__(self) -> None:
+        super().__init__(HTTP_400_BAD_REQUEST, "Comment is too long")
+
+class CommentServerError(InstacloneHttpException):
+    def __init__(self) -> None:
+        super().__init__(HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error")

--- a/instaclone/app/comment/errors.py
+++ b/instaclone/app/comment/errors.py
@@ -1,1 +1,11 @@
-# simple test
+from instaclone.common.errors import InstacloneHttpException
+
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_404_NOT_FOUND
+
+class CommentNotFoundError(InstacloneHttpException):
+    def __init__(self) -> None:
+        super().__init__(HTTP_404_NOT_FOUND, "Comment not exists")
+
+class CommentPermissionError(InstacloneHttpException):
+    def __init__(self) -> None:
+        super().__init__(HTTP_401_UNAUTHORIZED, "Comment Permission Error")

--- a/instaclone/app/comment/models.py
+++ b/instaclone/app/comment/models.py
@@ -14,7 +14,7 @@ class Comment(Base):
     # user_id
     user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.user_id"))
     # post_id
-    post_id: Mapped[int] = mapped_column(BigInteger)
+    post_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("posts.post_id"))
     # comment_id
     comment_id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     # parent_id
@@ -26,5 +26,5 @@ class Comment(Base):
      # relationships
     user: Mapped["User"] = relationship("User", back_populates="comments")
     post: Mapped["Post"] = relationship("Post", back_populates="comments")
-    replies: Mapped[list["Comment"]] = relationship("Comment", back_populates="parent", cascade="all, delete-orphan")
+    replies: Mapped[list["Comment"]] = relationship("Comment", back_populates="parent", cascade="all, delete-orphan", lazy="selectin")
     parent: Mapped[Optional["Comment"]] = relationship("Comment", remote_side="Comment.comment_id", back_populates="replies")

--- a/instaclone/app/comment/service.py
+++ b/instaclone/app/comment/service.py
@@ -1,39 +1,43 @@
-# from typing import Annotated
-# from fastapi import Depends
-# from instaclone.app.comment.dto.responses import CommentDetailResponse
-# # from instaclone.app.comment.errors import
-# from instaclone.app.comment.store import CommentStore
-# from instaclone.app.post.errors import PostNotFoundError
-# from instaclone.app.post.store import PostStore
+from typing import Annotated, Sequence
+from fastapi import Depends
 
+from instaclone.app.comment.store import CommentStore
+from instaclone.app.comment.models import Comment
+from instaclone.app.comment.errors import CommentNotFoundError
 
-# class CommentService:
-#     def __init__(
-#         self,
-#         comments_store: CommentStore = Depends(),
-#         post_store: PostStore = Depends()
-#     ):
-#         self.comments_store = comments_store
-#         self.post_store = post_store
-#         return
+class CommentService:
+    def __init__(self, comments_store: Annotated[CommentStore, Depends()]):
+        self.comments_store = comments_store
 
-#     async def create_comment(
-#         self,
-#         user_id: int,
-#         post_id: int,
-#         parent_id: int | None,
-#         comment_text: str,
-#     ) -> CommentDetailResponse:
-#         comment = await self.comments_store.create_comment(user_id=user_id, post_id=post_id, parent_id=parent_id, comment_text=comment_text)
-#         return CommentDetailResponse.from_comment(comment)
+    async def create_comment(
+        self,
+        user_id: int,
+        post_id: int,
+        parent_id: int | None,
+        comment_text: str,
+    ) -> Comment:
+        comment = await self.comments_store.create_comment(user_id=user_id, post_id=post_id, parent_id=parent_id, comment_text=comment_text)
+        return comment
     
-#     async def list_coments(
-#         self,
-#         post_id : int | None = None,
-#     ) -> list[CommentDetailResponse]:
-#         if post_id is not None:
-#             post = await self.post_store.get_post_by_id(post_id)
-#             if post is None:
-#                 raise PostNotFoundError()
-#         comments = await self.comments_store.get_comments(post_id)
-#         return [CommentDetailResponse.from_comment(comment) for comment in comments]
+    async def get_comment_by_id(self, comment_id: int) -> Comment:
+        comment = await self.comments_store.get_comment_by_id(comment_id)
+        if not comment:
+            raise CommentNotFoundError()
+        return comment
+    
+    async def get_comments_by_post(self, post_id: int) -> Sequence[Comment]:
+        comments = await self.comments_store.get_comments_by_post(post_id)
+        return comments
+    
+    async def edit_comment(
+        self,
+        user_id: int,
+        comment_id: int,
+        comment_text: str
+    ) -> Comment:
+        comment = await self.comments_store.edit_comment(user_id, comment_id, comment_text)
+        return comment
+
+    async def delete_comment(self, user_id: int, comment_id: int) -> str:
+        await self.comments_store.delete_comment(user_id, comment_id)
+        return "SUCCESS"

--- a/instaclone/app/comment/service.py
+++ b/instaclone/app/comment/service.py
@@ -29,6 +29,10 @@ class CommentService:
         comments = await self.comments_store.get_comments_by_post(post_id)
         return comments
     
+    async def get_replies_from_comment(self, comment_id: int) -> Sequence[Comment]:
+        comments = await self.comments_store.get_replies_from_comment(comment_id)
+        return comments
+    
     async def edit_comment(
         self,
         user_id: int,

--- a/instaclone/app/comment/service.py
+++ b/instaclone/app/comment/service.py
@@ -3,7 +3,6 @@ from fastapi import Depends
 
 from instaclone.app.comment.store import CommentStore
 from instaclone.app.comment.models import Comment
-from instaclone.app.comment.errors import CommentNotFoundError
 from instaclone.app.user.models import User
 from instaclone.app.post.models import Post
 
@@ -23,8 +22,6 @@ class CommentService:
     
     async def get_comment_by_id(self, comment_id: int) -> Comment:
         comment = await self.comments_store.get_comment_by_id(comment_id)
-        if not comment:
-            raise CommentNotFoundError()
         return comment
     
     async def get_comments_by_post(self, post_id: int) -> Sequence[Comment]:

--- a/instaclone/app/comment/service.py
+++ b/instaclone/app/comment/service.py
@@ -4,6 +4,8 @@ from fastapi import Depends
 from instaclone.app.comment.store import CommentStore
 from instaclone.app.comment.models import Comment
 from instaclone.app.comment.errors import CommentNotFoundError
+from instaclone.app.user.models import User
+from instaclone.app.post.models import Post
 
 class CommentService:
     def __init__(self, comments_store: Annotated[CommentStore, Depends()]):
@@ -11,12 +13,12 @@ class CommentService:
 
     async def create_comment(
         self,
-        user_id: int,
-        post_id: int,
+        user: User,
+        post: Post,
         parent_id: int | None,
         comment_text: str,
     ) -> Comment:
-        comment = await self.comments_store.create_comment(user_id=user_id, post_id=post_id, parent_id=parent_id, comment_text=comment_text)
+        comment = await self.comments_store.create_comment(user=user, post=post, parent_id=parent_id, comment_text=comment_text)
         return comment
     
     async def get_comment_by_id(self, comment_id: int) -> Comment:

--- a/instaclone/app/comment/store.py
+++ b/instaclone/app/comment/store.py
@@ -29,6 +29,14 @@ class CommentStore:
 
         return comments
     
+    async def get_replies_from_comment(self, comment_id: int) -> Sequence["Comment"]:
+        query = select(Comment).where(Comment.parent_id == comment_id)
+
+        result = await SESSION.scalars(query)
+        replies = result.all()
+        
+        return replies
+    
     async def edit_comment(self, user_id: int, comment_id: int, comment_text: str) -> Comment:
         comment = await SESSION.scalar(select(Comment).where(Comment.comment_id == comment_id))
         

--- a/instaclone/app/comment/views.py
+++ b/instaclone/app/comment/views.py
@@ -1,29 +1,57 @@
-# from typing import Annotated
-# from fastapi import APIRouter, Depends
+from typing import Annotated, List
+from fastapi import APIRouter, Depends
+from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 
-# from instaclone.app.comment.dto.requests import CommentCreateRequest
-# from instaclone.app.comment.dto.responses import CommentDetailResponse
-# from instaclone.app.comment.service import CommentService
+from instaclone.app.comment.dto.requests import CommentCreateRequest, CommentEditRequest
+from instaclone.app.comment.dto.responses import CommentDetailResponse
+from instaclone.app.comment.service import CommentService
 
-# from instaclone.app.user.models import User
-# from instaclone.app.user.views import login_with_header
-
-
-# comment_router = APIRouter()
+from instaclone.app.user.models import User
+from instaclone.app.user.views import login_with_header
 
 
-# @comment_router.post("", status_code=201)
-# async def create_comment(
-#     user: Annotated[User, Depends(login_with_header)],
-#     comment: CommentCreateRequest,
-#     comment_service: Annotated[CommentService, Depends()],
-# ) -> CommentDetailResponse:
-#     return await comment_service.create_comment(user_id=user.user_id, post_id=comment.post_id, parent_id=comment.parent_id, comment_text=comment.comment_text)
+comment_router = APIRouter()
 
+@comment_router.post("/", status_code=HTTP_201_CREATED)
+async def create_comment(
+    user: Annotated[User, Depends(login_with_header)],
+    comment_request: CommentCreateRequest,
+    comment_service: Annotated[CommentService, Depends()],
+) -> CommentDetailResponse:
+    comment = await comment_service.create_comment(user_id=user.user_id, post_id=comment_request.post_id, parent_id=comment_request.parent_id, comment_text=comment_request.comment_text)
+    return await CommentDetailResponse.from_comment(comment)
 
-# @comment_router.get("", status_code=200)
-# async def get_comments(
-#     comment_service: Annotated[CommentService, Depends()],
-#     post_id: int | None
-# ) -> list[CommentDetailResponse]:
-#     return await comment_service.list_coments(post_id)
+@comment_router.get("/{comment_id}", status_code=HTTP_200_OK)
+async def get_comment_by_id(
+    comment_id: int,
+    comment_service: Annotated[CommentService, Depends()]
+) -> CommentDetailResponse:
+    comment = await comment_service.get_comment_by_id(comment_id)
+    return await CommentDetailResponse.from_comment(comment)
+
+@comment_router.get("/list/{post_id}", status_code=HTTP_200_OK)
+async def get_comment_by_post(
+    post_id: int,
+    comment_service: Annotated[CommentService, Depends()]
+) -> List[CommentDetailResponse]:
+    comments = await comment_service.get_comments_by_post(post_id)
+    return [await CommentDetailResponse.from_comment(c) for c in comments]
+
+@comment_router.patch("/{comment_id}", status_code=HTTP_200_OK)
+async def edit_comment(
+    user: Annotated[User, Depends(login_with_header)],
+    comment_id: int,
+    comment_edit_request: CommentEditRequest,
+    comment_service: Annotated[CommentService, Depends()]
+) -> CommentDetailResponse:
+    comment = await comment_service.edit_comment(user.user_id, comment_id, comment_edit_request.comment_text)
+    return await CommentDetailResponse.from_comment(comment)
+
+@comment_router.delete("/{comment_id}", status_code=HTTP_200_OK)
+async def delete_comment(
+    user: Annotated[User, Depends(login_with_header)],
+    comment_id: int,
+    comment_service: Annotated[CommentService, Depends()]
+) -> str:
+    await comment_service.delete_comment(user.user_id, comment_id)
+    return "SUCCESS"

--- a/instaclone/app/comment/views.py
+++ b/instaclone/app/comment/views.py
@@ -29,6 +29,14 @@ async def get_comment_by_id(
     comment = await comment_service.get_comment_by_id(comment_id)
     return await CommentDetailResponse.from_comment(comment)
 
+@comment_router.get("/{comment_id}/replies", status_code=HTTP_200_OK)
+async def get_replies_from_comment(
+    comment_id: int,
+    comment_service: Annotated[CommentService, Depends()]
+) -> List[CommentDetailResponse]:
+    replies = await comment_service.get_replies_from_comment(comment_id)
+    return [await CommentDetailResponse.from_comment(r) for r in replies]
+
 @comment_router.get("/list/{post_id}", status_code=HTTP_200_OK)
 async def get_comment_by_post(
     post_id: int,

--- a/instaclone/app/post/models.py
+++ b/instaclone/app/post/models.py
@@ -29,4 +29,4 @@ class Post(Base):
     user: Mapped["User"] = relationship("User", back_populates="posts")
     # 1(story) to N(media)
     media: Mapped[list["Medium"]] = relationship("Medium", back_populates="post", lazy='selectin')
-    #comments: Mapped[list["Comment"]] = relationship("Comment", back_populates="post")
+    comments: Mapped[list["Comment"]] = relationship("Comment", back_populates="post")

--- a/instaclone/app/user/models.py
+++ b/instaclone/app/user/models.py
@@ -46,7 +46,7 @@ class User(Base):
     following_users: Mapped[List["Follower"]] = relationship("Follower", foreign_keys="[Follower.follower_id]", back_populates="follower")
     posts: Mapped[list["Post"]] = relationship("Post", back_populates="user", lazy="selectin")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="user", lazy="selectin")
-    #comments: Mapped[list["Comment"]] = relationship("Comment", back_populates="user")
+    comments: Mapped[list["Comment"]] = relationship("Comment", back_populates="user")
 
 class BlockedToken(Base):
     __tablename__ = "blocked_token"


### PR DESCRIPTION
[POST] /api/comments - 댓글 추가
[GET] /api/comments/{comment_id} - 댓글 정보
[GET] /api/comments/list/{post_id} - 게시물에 달린 댓글 정보
[GET] /api/comments/{comment_id}/replies - 댓글의 대댓글 정보
[PATCH] /api/comments/{comment_id} - 댓글 수정
[DELETE] /api/comments/{comment_id} - 댓글 삭

댓글 관련된 기능 구현입니다. comment 정보를 얻을 때 지금은 생성된 순서대로 되어 있는데, 후에 생성된 시각을 추가하거나 좋아요 기능이 구현된 이후 좋아요가 많은 댓글을 위로 보내는 것도 괜찮을 것 같습니다.